### PR TITLE
Fix issues with spv sync

### DIFF
--- a/bin/spvnode
+++ b/bin/spvnode
@@ -8,7 +8,7 @@ const assert = require('assert');
 const SPVNode = require('../lib/node/spvnode');
 const Outpoint = require('../lib/primitives/outpoint');
 
-const node = SPVNode({
+const node = new SPVNode({
   config: true,
   argv: true,
   env: true,
@@ -17,6 +17,7 @@ const node = SPVNode({
   logLevel: 'debug',
   db: 'leveldb',
   persistent: true,
+  memory: false,
   workers: true,
   listen: true,
   loader: require

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -500,10 +500,6 @@ class Chain extends AsyncEmitter {
       state.flags |= Script.flags.VERIFY_SIGHASH_FORKID;
     }
 
-    // DAA is now enabled.
-    if (height >= this.network.block.daaheight)
-      state.daa = true;
-
     // CHECKSEQUENCEVERIFY and median time
     // past locktimes are now usable (bip9 & bip113).
     if (await this.isActive(prev, deployments.csv)) {
@@ -2230,8 +2226,8 @@ class Chain extends AsyncEmitter {
     if (pow.noRetargeting)
       return prev.bits;
 
-    // IsDAAEnabled
-    if (this.state.hasDAA()) {
+    // DAA is now enabled.
+    if (this.tip.height >= this.network.block.daaheight) {
       // Do not retarget
       if (pow.targetReset) {
         // Special behavior for (simnet and testnet):
@@ -2854,7 +2850,6 @@ class DeploymentState {
     this.bip34 = false;
     this.bip91 = false;
     this.bip148 = false;
-    this.daa = false;
   }
 
   /**
@@ -2936,15 +2931,6 @@ class DeploymentState {
 
   hasBIP148() {
     return this.bip148;
-  }
-
-  /**
-   * Test whether DAA is active.
-   * @returns {Boolean}
-   */
-
-  hasDAA() {
-    return this.daa;
   }
 }
 

--- a/lib/primitives/merkleblock.js
+++ b/lib/primitives/merkleblock.js
@@ -247,8 +247,7 @@ class MerkleBlock extends AbstractBlock {
     if (totalTX === 0)
       throw new Error('Zero transactions.');
 
-    if (totalTX > consensus.MAX_BLOCK_SIZE / 60)
-      throw new Error('Too many transactions.');
+    // FIXME: Track the maximum block size we've seen and use it here.
 
     if (hashes.length > totalTX)
       throw new Error('Too many hashes.');

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -114,7 +114,7 @@ main.checkpointMap = {
  * @default
  */
 
-main.lastCheckpoint = 478559;
+main.lastCheckpoint = 504031;
 
 /**
  * @const {Number}
@@ -517,7 +517,7 @@ testnet.checkpointMap = {
   1188697: 'fb47e0ab0d2448f71192a09fe61bc9c46cd3b4e7bd778091d00e170000000000'
 };
 
-testnet.lastCheckpoint = 1050000;
+testnet.lastCheckpoint = 1188697;
 
 testnet.halvingInterval = 210000;
 


### PR DESCRIPTION
`getDeploymentState` was not called in spv mode, so moved the DAA check directly to `getTarget`.

bitcoin-abc doesn't validate max transactions per block. Updated, including the same comment.