### PR TITLE
chain: fix testnet diff calculation

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2260,24 +2260,26 @@ class Chain extends AsyncEmitter {
     }
 
     // Do not retarget
-    if (pow.targetReset) {
-      // Special behavior for testnet:
-      if (time > prev.time + pow.targetSpacing * 2)
-        return pow.bits;
+    if ((prev.height + 1) % pow.retargetInterval !== 0) {
+      if (pow.targetReset) {
+        // Special behavior for testnet:
+        if (time > prev.time + pow.targetSpacing * 2)
+          return pow.bits;
 
-      while (prev.height !== 0
-        && prev.height % pow.retargetInterval !== 0
-        && prev.bits === pow.bits) {
-        const cache = this.getPrevCache(prev);
+        while (prev.height !== 0
+          && prev.height % pow.retargetInterval !== 0
+          && prev.bits === pow.bits) {
+          const cache = this.getPrevCache(prev);
 
-        if (cache) {
-          prev = cache;
-          continue;
+          if (cache)
+            prev = cache;
+          else
+            prev = await this.getPrevious(prev);
+
+          assert(prev);
         }
-
-        prev = await this.getPrevious(prev);
-        assert(prev);
       }
+      return prev.bits;
     }
 
     if (prev.bits === pow.bits)


### PR DESCRIPTION
Syncing with `checkpoints: false` was throwing a `bad-diffbits` verification failure.