### PR TITLE
chain: fix testnet diff calculation

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2270,14 +2270,14 @@ class Chain extends AsyncEmitter {
         && prev.bits === pow.bits) {
         const cache = this.getPrevCache(prev);
 
-        if (cache) {
+        if (cache)
           prev = cache;
-          continue;
-        }
+        else
+          prev = await this.getPrevious(prev);
 
-        prev = await this.getPrevious(prev);
         assert(prev);
       }
+      return prev.bits;
     }
 
     if (prev.bits === pow.bits)


### PR DESCRIPTION
A fix for testnet when syncing with `checkpoints: false`