### PR TITLE
Fix cashaddr RPC calls on non-main networks.

### DIFF
--- a/lib/indexer/addrindexer.js
+++ b/lib/indexer/addrindexer.js
@@ -146,7 +146,7 @@ class AddrIndexer extends Indexer {
     const coins = [];
 
     for (const addr of addrs) {
-      const hash = Address.getHash(addr);
+      const hash = Address.getHash(addr, undefined, this.network);
 
       const keys = await this.db.keys({
         gte: layout.C.min(hash),
@@ -177,7 +177,7 @@ class AddrIndexer extends Indexer {
     const hashes = Object.create(null);
 
     for (const addr of addrs) {
-      const hash = Address.getHash(addr);
+      const hash = Address.getHash(addr, undefined, this.network);
 
       await this.db.keys({
         gte: layout.T.min(hash),

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -558,7 +558,7 @@ class Mempool extends EventEmitter {
     const out = [];
 
     for (const addr of addrs) {
-      const hash = Address.getHash(addr, 'hex');
+      const hash = Address.getHash(addr, 'hex', this.network);
       const coins = this.coinIndex.get(hash);
 
       for (const coin of coins)
@@ -604,7 +604,7 @@ class Mempool extends EventEmitter {
     const out = [];
 
     for (const addr of addrs) {
-      const hash = Address.getHash(addr, 'hex');
+      const hash = Address.getHash(addr, 'hex', this.network);
       const txs = this.txIndex.getMeta(hash);
 
       for (const tx of txs)


### PR DESCRIPTION
Fixes #64.

As far as I was able to figure this out the problem only appears on non-main networks. With this change I was able to get tx/coin using a CashAddr address. 