### PR TITLE
Separate Mempool indexer

### DIFF
--- a/lib/mempool/indexer.js
+++ b/lib/mempool/indexer.js
@@ -476,11 +476,6 @@ class IndexedCoin {
   toCoin() {
     return Coin.fromTX(this.tx, this.index, -1);
   }
-
-  inspect() {
-    return `<IndexedCoin tx=${this.tx.hash().toString('hex')}`
-    + ` index=${this.index}>`;
-  }
 }
 
 module.exports = MempoolIndexer;

--- a/lib/mempool/indexer.js
+++ b/lib/mempool/indexer.js
@@ -18,10 +18,10 @@ const Coin = require('../primitives/coin');
  * Handles TXIndex and CoinIndex for looking up by address.
  *
  * Coin index in mempool keeps track of the coins available for an address
- * in the mempool, those that have not been indexed by indexer yet.
+ * in the mempool, those that have not been indexed by chain indexer yet.
  *
  * There are several reasons transaction can be added or removed from the
- * mempool, as well as coins assosiated with addresses with it.
+ * mempool, as well as coins associated with addresses with it.
  *  - Transaction was received from the network or orphan got resolved:
  *    - events: add entry and tx
  *    - We want to remove coins that are in tx inputs.
@@ -32,19 +32,19 @@ const Coin = require('../primitives/coin');
  *  - Transaction was included in block
  *    - events: `remove entry` and `confirmed` OR `double spend`
  *      (Can potentially resolve orphans)
- *    - We don't want to recover inputs as they are spent in chain.
- *    - We don't need outputs as well, because they are now part of the
- *      chain indexer.
- *    - On double spend we might need to partially recover
- *      double spent transaction's inputs as coins if they are in mempool
- *      (partial double spent test case)
+ *    - if tx was confirmed we wont have tx.hash() in the mempool,
+ *      so we can leave things to removeEntry.
+ *    - On double spend transaction that was spent in mempool
+ *      will get unindexed(remove entry), which will recover
+ *      all coins that are in the mempool. (inputs that were
+ *      double spent wont be in the mempool (getTX will fail).
  *  - Transaction was removed because of memory constraints
  *    - events: `remove entry`
  *    - In this case we want to recover inputs as coins
  *  - on reorganization we need to also clean up coins
  *    - events: `unconfirmed` and `add entry` + `tx`
  *    - add tx creates new coins
- *    - on unocnfirmed we need to recover outputs as coins
+ *    - on unconfirmed we need to recover outputs as coins
  *      (Unless they are not spent in mempool)
  *
  * We don't need to take care of conflict as
@@ -78,23 +78,9 @@ class MempoolIndexer {
    */
 
   init() {
-    this.mempool.on('confirmed', (tx, block) => this.confirmed(tx, block));
     this.mempool.on('unconfirmed', (tx, block) => this.unconfirmed(tx, block));
     this.mempool.on('add entry', (entry, view) => this.addEntry(entry, view));
     this.mempool.on('remove entry', entry => this.removeEntry(entry));
-    this.mempool.on('double spend', entry => this.doubleSpend(entry));
-  }
-  /**
-   * We have new tx in the mempool.
-   * We can index to TXIndex here.
-   * - We received it from the network.
-   * - Block was disconnected.
-   * - Orphan got resolved
-   * @param {TX} tx
-   * @param {CoinView} view
-   */
-
-  addTX(tx, view) {
   }
 
   /**
@@ -155,19 +141,6 @@ class MempoolIndexer {
   }
 
   /**
-   * Transaction was included in the block.
-   * We want to get rid of the input coins as well as output coins.
-   * (if there are any)
-   * This event comes after remove entry, which recovers inputs
-   * as coins, we want to get rid of those coins as well.
-   * @param {TX} tx
-   * @param {Block} block
-   */
-
-  confirmed(tx, block) {
-  }
-
-  /**
    * Block disconnected and we recover coins if they are available.
    * This event comes after `tx` and `add entry`, we might want to
    * check if outputs indexed by those are already spent in the mempool.
@@ -176,15 +149,12 @@ class MempoolIndexer {
    */
 
   unconfirmed(tx, block) {
-  }
+    const hash = tx.hash();
 
-  /**
-   * Transaction was double spent in the mempool.
-   * We want to recover coisn that are not spent in the mempool.
-   * @param {MempoolEntry} entry
-   */
-
-  doubleSpend(entry) {
+    for (let i = 0; i < tx.outputs.length; i++) {
+      if (this.mempool.isSpent(hash, i))
+        this.coinIndex.remove(hash, i);
+    }
   }
 
   /**
@@ -198,28 +168,50 @@ class MempoolIndexer {
   }
 
   /**
-   * Find all transactions partaining to a certain address.
+   * Find all transactions pertaining to a certain address.
    * Note: this does not accept multiple addresses.
-   * @param {Address} addr
+   * @param {Address} addrs
    * @returns {TX[]}
    */
 
-  getTXByAddress(addr) {
-    const hash = Address.getHash(addr);
+  getTXByAddress(addrs) {
+    if (!Array.isArray(addrs))
+      addrs = [addrs];
 
-    return this.txIndex.get(hash);
+    const out = [];
+
+    for (const addr of addrs) {
+      const hash = Address.getHash(addr, this.network);
+      const txs = this.txIndex.get(hash);
+
+      for (const tx of txs)
+        out.push(tx);
+    }
+
+    return out;
   }
 
   /**
    * Find all transactions pertaining to a certain address.
-   * @param {Address} addr
+   * @param {Address} addrs
    * @param {TXMeta[]]}
    */
 
-  getMetaByAddress(addr) {
-    const hash = Address.getHash(addr);
+  getMetaByAddress(addrs) {
+    if (!Array.isArray(addrs))
+      addrs = [addrs];
 
-    return this.txIndex.getMeta(hash);
+    const out = [];
+
+    for (const addr of addrs) {
+      const hash = Address.getHash(addr);
+      const txs = this.txIndex.getMeta(hash);
+
+      for (const tx of txs)
+        out.push(tx);
+    }
+
+    return out;
   }
 
   /**
@@ -228,10 +220,21 @@ class MempoolIndexer {
    * @return {Coin[]}
    */
 
-  getCoinsByAddress(addr) {
-    const hash = Address.getHash(addr);
+  getCoinsByAddress(addrs) {
+    if (!Array.isArray(addrs))
+      addrs = [addrs];
 
-    return this.coinIndex.get(hash);
+    const out = [];
+
+    for (const addr of addrs) {
+      const hash = Address.getHash(addr);
+      const coins = this.coinIndex.get(hash);
+
+      for (const coin of coins)
+        out.push(coin);
+    }
+
+    return out;
   }
 }
 

--- a/lib/mempool/indexer.js
+++ b/lib/mempool/indexer.js
@@ -9,7 +9,6 @@
 const assert = require('bsert');
 const {BufferMap} = require('buffer-map');
 const Address = require('../primitives/address');
-const Network = require('../protocol/network');
 const Outpoint = require('../primitives/outpoint');
 const TXMeta = require('../primitives/txmeta');
 const Coin = require('../primitives/coin');

--- a/lib/mempool/indexer.js
+++ b/lib/mempool/indexer.js
@@ -1,0 +1,484 @@
+/*!
+ * mempool/index.js - mempool for bcoin
+ * Copyright (c) 2018, the bcoin developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const {BufferMap} = require('buffer-map');
+const Address = require('../primitives/address');
+const Network = require('../protocol/network');
+const Outpoint = require('../primitives/outpoint');
+const TXMeta = require('../primitives/txmeta');
+const Coin = require('../primitives/coin');
+
+/**
+ * Mempool indexer
+ * Handles TXIndex and CoinIndex for looking up by address.
+ *
+ * Coin index in mempool keeps track of the coins available for an address
+ * in the mempool, those that have not been indexed by indexer yet.
+ *
+ * There are several reasons transaction can be added or removed from the
+ * mempool, as well as coins assosiated with addresses with it.
+ *  - Transaction was received from the network or orphan got resolved:
+ *    - events: add entry and tx
+ *    - We want to remove coins that are in tx inputs.
+ *      If there are any - Meaning they are spending transaction in mempool
+ *    - We want to add outputs as coins in the mempool.
+ *    - If outputs are resolving orphans those orphans will be added via same
+ *      events (tx and add entry)
+ *  - Transaction was included in block
+ *    - events: `remove entry` and `confirmed` OR `double spend`
+ *      (Can potentially resolve orphans)
+ *    - We don't want to recover inputs as they are spent in chain.
+ *    - We don't need outputs as well, because they are now part of the
+ *      chain indexer.
+ *    - On double spend we might need to partially recover
+ *      double spent transaction's inputs as coins if they are in mempool
+ *      (partial double spent test case)
+ *  - Transaction was removed because of memory constraints
+ *    - events: `remove entry`
+ *    - In this case we want to recover inputs as coins
+ *  - on reorganization we need to also clean up coins
+ *    - events: `unconfirmed` and `add entry` + `tx`
+ *    - add tx creates new coins
+ *    - on unocnfirmed we need to recover outputs as coins
+ *      (Unless they are not spent in mempool)
+ *
+ * We don't need to take care of conflict as
+ * that event prevents tx from entering the mempool.
+ *
+ * and orphan related events as they are not part of
+ * the coin or tx indexers as orphans.
+ *
+ *
+ * @alias module:mempool.MempoolIndexer
+ */
+
+class MempoolIndexer {
+  /**
+   * Create a mempool indexer.
+   * @param {Mempool} mempool
+   */
+
+  constructor(options) {
+    this.options = new MempoolIndexerOptions(options);
+    this.mempool = this.options.mempool;
+
+    this.coinIndex = new CoinIndex();
+    this.txIndex = new TXIndex();
+
+    this.init();
+  }
+
+  /**
+   * Start listening for the mempool events
+   */
+
+  init() {
+    this.mempool.on('confirmed', (tx, block) => this.confirmed(tx, block));
+    this.mempool.on('unconfirmed', (tx, block) => this.unconfirmed(tx, block));
+    this.mempool.on('add entry', (entry, view) => this.addEntry(entry, view));
+    this.mempool.on('remove entry', entry => this.removeEntry(entry));
+    this.mempool.on('double spend', entry => this.doubleSpend(entry));
+  }
+  /**
+   * We have new tx in the mempool.
+   * We can index to TXIndex here.
+   * - We received it from the network.
+   * - Block was disconnected.
+   * - Orphan got resolved
+   * @param {TX} tx
+   * @param {CoinView} view
+   */
+
+  addTX(tx, view) {
+  }
+
+  /**
+   * We have new entry in the mempool.
+   * `add entry` is emitted after `tx`.
+   * We can index coins.
+   * - We received it from the network.
+   * - Block was disconnected.
+   * - Orphan got resolved
+   * @param {MempoolEntry} entry
+   * @param {CoinView} view
+   */
+
+  addEntry(entry, view) {
+    const tx = entry.tx;
+
+    this.txIndex.insert(entry, view);
+
+    for (const {prevout} of tx.inputs) {
+      const {hash, index} = prevout;
+
+      this.coinIndex.remove(hash, index);
+    }
+
+    for (let i = 0; i < tx.outputs.length; i++)
+      this.coinIndex.insert(tx, i);
+  }
+
+  /**
+   * Transaction was removed from mempool.
+   * This might happen for several reasons:
+   *  - Mempool size limit got rid of it.
+   *  - Transaction was included in block.
+   *  - Double spend in a block
+   *  - After reorg tx is no longer final
+   * We concentrate on recovering inputs as coins.
+   * @param {MempoolEntry} entry
+   */
+
+  removeEntry(entry) {
+    const tx = entry.tx;
+    const hash = tx.hash();
+
+    this.txIndex.remove(hash);
+
+    for (const {prevout} of tx.inputs) {
+      const {hash, index} = prevout;
+      const prev = this.mempool.getTX(hash);
+
+      if (!prev)
+        continue;
+
+      this.coinIndex.insert(prev, index);
+    }
+
+    for (let i = 0; i < tx.outputs.length; i++)
+      this.coinIndex.remove(hash, i);
+  }
+
+  /**
+   * Transaction was included in the block.
+   * We want to get rid of the input coins as well as output coins.
+   * (if there are any)
+   * This event comes after remove entry, which recovers inputs
+   * as coins, we want to get rid of those coins as well.
+   * @param {TX} tx
+   * @param {Block} block
+   */
+
+  confirmed(tx, block) {
+  }
+
+  /**
+   * Block disconnected and we recover coins if they are available.
+   * This event comes after `tx` and `add entry`, we might want to
+   * check if outputs indexed by those are already spent in the mempool.
+   * @param {TX} tx
+   * @param {Block} block
+   */
+
+  unconfirmed(tx, block) {
+  }
+
+  /**
+   * Transaction was double spent in the mempool.
+   * We want to recover coisn that are not spent in the mempool.
+   * @param {MempoolEntry} entry
+   */
+
+  doubleSpend(entry) {
+  }
+
+  /**
+   * Reset indexes
+   * @private
+   */
+
+  reset() {
+    this.txIndex.reset();
+    this.coinIndex.reset();
+  }
+
+  /**
+   * Find all transactions partaining to a certain address.
+   * Note: this does not accept multiple addresses.
+   * @param {Address} addr
+   * @returns {TX[]}
+   */
+
+  getTXByAddress(addr) {
+    const hash = Address.getHash(addr);
+
+    return this.txIndex.get(hash);
+  }
+
+  /**
+   * Find all transactions pertaining to a certain address.
+   * @param {Address} addr
+   * @param {TXMeta[]]}
+   */
+
+  getMetaByAddress(addr) {
+    const hash = Address.getHash(addr);
+
+    return this.txIndex.getMeta(hash);
+  }
+
+  /**
+   * Find all coins pertaining to a certain address.
+   * @param {Address} addr
+   * @return {Coin[]}
+   */
+
+  getCoinsByAddress(addr) {
+    const hash = Address.getHash(addr);
+
+    return this.coinIndex.get(hash);
+  }
+}
+
+/**
+ * Mempool Indexer Options
+ * @alias module:mempool.MempoolIndexerOptions
+ */
+
+class MempoolIndexerOptions {
+  /**
+   * Create indexer options.
+   * @param {Object}
+   */
+
+  constructor(options) {
+    this.mempool = null;
+
+    this.fromOptions(options);
+  }
+
+  /**
+   * Inject properties from object.
+   * @private
+   * @param {Object} options
+   * returns {MempoolIndexerOptions}
+   */
+
+  fromOptions(options) {
+    assert(options, 'Mempool indexer requires options.');
+    assert(options.mempool && typeof options.mempool === 'object',
+      'Mempool indexer requires a mempool.'
+    );
+
+    this.mempool = options.mempool;
+
+    return this;
+  }
+}
+
+/**
+ * TX Address Index
+ * @ignore
+ */
+
+class TXIndex {
+  /**
+   * Create TX address index.
+   * @constructor
+   */
+
+  constructor() {
+    // Map of addr->entries.
+    this.index = new BufferMap();
+
+    // Map of txid->addrs.
+    this.map = new BufferMap();
+  }
+
+  reset() {
+    this.index.clear();
+    this.map.clear();
+  }
+
+  get(addr) {
+    const items = this.index.get(addr);
+
+    if (!items)
+      return [];
+
+    const out = [];
+
+    for (const entry of items.values())
+      out.push(entry.tx);
+
+    return out;
+  }
+
+  getMeta(addr) {
+    const items = this.index.get(addr);
+
+    if (!items)
+      return [];
+
+    const out = [];
+
+    for (const entry of items.values()) {
+      const meta = TXMeta.fromTX(entry.tx);
+      meta.mtime = entry.time;
+      out.push(meta);
+    }
+
+    return out;
+  }
+
+  insert(entry, view) {
+    const tx = entry.tx;
+    const hash = tx.hash();
+    const addrs = tx.getHashes(view);
+
+    if (addrs.length === 0)
+      return;
+
+    for (const addr of addrs) {
+      let items = this.index.get(addr);
+
+      if (!items) {
+        items = new BufferMap();
+        this.index.set(addr, items);
+      }
+
+      assert(!items.has(hash));
+      items.set(hash, entry);
+    }
+
+    this.map.set(hash, addrs);
+  }
+
+  remove(hash) {
+    const addrs = this.map.get(hash);
+
+    if (!addrs)
+      return;
+
+    for (const addr of addrs) {
+      const items = this.index.get(addr);
+
+      assert(items);
+      assert(items.has(hash));
+
+      items.delete(hash);
+
+      if (items.size === 0)
+        this.index.delete(addr);
+    }
+
+    this.map.delete(hash);
+  }
+}
+
+/**
+ * Coin Address Index
+ * @ignore
+ */
+
+class CoinIndex {
+  /**
+   * Create coin address index.
+   * @constructor
+   */
+
+  constructor() {
+    // Map of addr->coins.
+    this.index = new BufferMap();
+
+    // Map of outpoint->addr.
+    this.map = new BufferMap();
+  }
+
+  reset() {
+    this.index.clear();
+    this.map.clear();
+  }
+
+  get(addr) {
+    const items = this.index.get(addr);
+
+    if (!items)
+      return [];
+
+    const out = [];
+
+    for (const coin of items.values())
+      out.push(coin.toCoin());
+
+    return out;
+  }
+
+  insert(tx, index) {
+    const output = tx.outputs[index];
+    const hash = tx.hash();
+    const addr = output.getHash();
+
+    if (!addr)
+      return;
+
+    let items = this.index.get(addr);
+
+    if (!items) {
+      items = new BufferMap();
+      this.index.set(addr, items);
+    }
+
+    const key = Outpoint.toKey(hash, index);
+
+    assert(!items.has(key));
+    items.set(key, new IndexedCoin(tx, index));
+
+    this.map.set(key, addr);
+  }
+
+  remove(hash, index) {
+    const key = Outpoint.toKey(hash, index);
+    const addr = this.map.get(key);
+
+    if (!addr)
+      return;
+
+    const items = this.index.get(addr);
+
+    assert(items);
+    assert(items.has(key));
+    items.delete(key);
+
+    if (items.size === 0)
+      this.index.delete(addr);
+
+    this.map.delete(key);
+  }
+}
+
+/**
+ * Indexed Coin
+ * @ignore
+ */
+
+class IndexedCoin {
+  /**
+   * Create an indexed coin.
+   * @constructor
+   * @param {TX} tx
+   * @param {Number} index
+   */
+
+  constructor(tx, index) {
+    this.tx = tx;
+    this.index = index;
+  }
+
+  toCoin() {
+    return Coin.fromTX(this.tx, this.index, -1);
+  }
+
+  inspect() {
+    return `<IndexedCoin tx=${this.tx.hash().toString('hex')}`
+    + ` index=${this.index}>`;
+  }
+}
+
+module.exports = MempoolIndexer;

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -19,7 +19,6 @@ const policy = require('../protocol/policy');
 const util = require('../utils/util');
 const random = require('bcrypto/lib/random');
 const {VerifyError} = require('../protocol/errors');
-const Address = require('../primitives/address');
 const Script = require('../script/script');
 const Outpoint = require('../primitives/outpoint');
 const TX = require('../primitives/tx');
@@ -72,9 +71,6 @@ class Mempool extends EventEmitter {
     this.map = new BufferMap();
     this.spents = new BufferMap();
     this.rejects = new RollingFilter(120000, 0.000001);
-
-    this.coinIndex = new CoinIndex();
-    this.txIndex = new TXIndex();
   }
 
   /**
@@ -364,8 +360,6 @@ class Mempool extends EventEmitter {
     this.orphans.clear();
     this.map.clear();
     this.spents.clear();
-    this.coinIndex.reset();
-    this.txIndex.reset();
 
     this.freeCount = 0;
     this.lastTime = 0;
@@ -575,20 +569,12 @@ class Mempool extends EventEmitter {
    */
 
   getCoinsByAddress(addrs) {
-    if (!Array.isArray(addrs))
-      addrs = [addrs];
+    process.emitWarning(
+      'deprecated, use node.mempoolIndex.getCoinsByAddress',
+      'DeprecationWarning'
+    );
 
-    const out = [];
-
-    for (const addr of addrs) {
-      const hash = Address.getHash(addr);
-      const coins = this.coinIndex.get(hash);
-
-      for (const coin of coins)
-        out.push(coin);
-    }
-
-    return out;
+    return [];
   }
 
   /**
@@ -598,20 +584,12 @@ class Mempool extends EventEmitter {
    */
 
   getTXByAddress(addrs) {
-    if (!Array.isArray(addrs))
-      addrs = [addrs];
+    process.emitWarning(
+      'deprecated, use node.mempoolIndex.getTXByAddress',
+      'DeprecationWarning'
+    );
 
-    const out = [];
-
-    for (const addr of addrs) {
-      const hash = Address.getHash(addr, this.network);
-      const txs = this.txIndex.get(hash);
-
-      for (const tx of txs)
-        out.push(tx);
-    }
-
-    return out;
+    return [];
   }
 
   /**
@@ -621,20 +599,12 @@ class Mempool extends EventEmitter {
    */
 
   getMetaByAddress(addrs) {
-    if (!Array.isArray(addrs))
-      addrs = [addrs];
+    process.emitWarning(
+      'deprecated, use node.mempoolIndex.getMetaByAddress',
+      'DeprecationWarning'
+    );
 
-    const out = [];
-
-    for (const addr of addrs) {
-      const hash = Address.getHash(addr, this.network);
-      const txs = this.txIndex.getMeta(hash);
-
-      for (const tx of txs)
-        out.push(tx);
-    }
-
-    return out;
+    return [];
   }
 
   /**
@@ -889,7 +859,7 @@ class Mempool extends EventEmitter {
     // Contextual verification.
     await this.verify(entry, view);
 
-    // Add and index the entry.
+    // Add the entry.
     await this.addEntry(entry, view);
 
     // Trim size if we're too big.
@@ -1776,9 +1746,6 @@ class Mempool extends EventEmitter {
       this.spents.set(key, entry);
     }
 
-    if (this.options.indexAddress && view)
-      this.indexEntry(entry, view);
-
     this.size += entry.memUsage();
   }
 
@@ -1802,57 +1769,7 @@ class Mempool extends EventEmitter {
       this.spents.delete(key);
     }
 
-    if (this.options.indexAddress)
-      this.unindexEntry(entry);
-
     this.size -= entry.memUsage();
-  }
-
-  /**
-   * Index an entry by address.
-   * @private
-   * @param {MempoolEntry} entry
-   * @param {CoinView} view
-   */
-
-  indexEntry(entry, view) {
-    const tx = entry.tx;
-
-    this.txIndex.insert(entry, view);
-
-    for (const {prevout} of tx.inputs) {
-      const {hash, index} = prevout;
-      this.coinIndex.remove(hash, index);
-    }
-
-    for (let i = 0; i < tx.outputs.length; i++)
-      this.coinIndex.insert(tx, i);
-  }
-
-  /**
-   * Unindex an entry by address.
-   * @private
-   * @param {MempoolEntry} entry
-   */
-
-  unindexEntry(entry) {
-    const tx = entry.tx;
-    const hash = tx.hash();
-
-    this.txIndex.remove(hash);
-
-    for (const {prevout} of tx.inputs) {
-      const {hash, index} = prevout;
-      const prev = this.getTX(hash);
-
-      if (!prev)
-        continue;
-
-      this.coinIndex.insert(prev, index);
-    }
-
-    for (let i = 0; i < tx.outputs.length; i++)
-      this.coinIndex.remove(hash, i);
   }
 
   /**
@@ -2095,11 +2012,6 @@ class MempoolOptions {
       this.persistent = options.persistent;
     }
 
-    if (options.indexAddress != null) {
-      assert(typeof options.indexAddress === 'boolean');
-      this.indexAddress = options.indexAddress;
-    }
-
     return this;
   }
 
@@ -2111,210 +2023,6 @@ class MempoolOptions {
 
   static fromOptions(options) {
     return new MempoolOptions().fromOptions(options);
-  }
-}
-
-/**
- * TX Address Index
- * @ignore
- */
-
-class TXIndex {
-  /**
-   * Create TX address index.
-   * @constructor
-   */
-
-  constructor() {
-    // Map of addr->entries.
-    this.index = new BufferMap();
-
-    // Map of txid->addrs.
-    this.map = new BufferMap();
-  }
-
-  reset() {
-    this.index.clear();
-    this.map.clear();
-  }
-
-  get(addr) {
-    const items = this.index.get(addr);
-
-    if (!items)
-      return [];
-
-    const out = [];
-
-    for (const entry of items.values())
-      out.push(entry.tx);
-
-    return out;
-  }
-
-  getMeta(addr) {
-    const items = this.index.get(addr);
-
-    if (!items)
-      return [];
-
-    const out = [];
-
-    for (const entry of items.values()) {
-      const meta = TXMeta.fromTX(entry.tx);
-      meta.mtime = entry.time;
-      out.push(meta);
-    }
-
-    return out;
-  }
-
-  insert(entry, view) {
-    const tx = entry.tx;
-    const hash = tx.hash();
-    const addrs = tx.getHashes(view);
-
-    if (addrs.length === 0)
-      return;
-
-    for (const addr of addrs) {
-      let items = this.index.get(addr);
-
-      if (!items) {
-        items = new BufferMap();
-        this.index.set(addr, items);
-      }
-
-      assert(!items.has(hash));
-      items.set(hash, entry);
-    }
-
-    this.map.set(hash, addrs);
-  }
-
-  remove(hash) {
-    const addrs = this.map.get(hash);
-
-    if (!addrs)
-      return;
-
-    for (const addr of addrs) {
-      const items = this.index.get(addr);
-
-      assert(items);
-      assert(items.has(hash));
-
-      items.delete(hash);
-
-      if (items.size === 0)
-        this.index.delete(addr);
-    }
-
-    this.map.delete(hash);
-  }
-}
-
-/**
- * Coin Address Index
- * @ignore
- */
-
-class CoinIndex {
-  /**
-   * Create coin address index.
-   * @constructor
-   */
-
-  constructor() {
-    // Map of addr->coins.
-    this.index = new BufferMap();
-
-    // Map of outpoint->addr.
-    this.map = new BufferMap();
-  }
-
-  reset() {
-    this.index.clear();
-    this.map.clear();
-  }
-
-  get(addr) {
-    const items = this.index.get(addr);
-
-    if (!items)
-      return [];
-
-    const out = [];
-
-    for (const coin of items.values())
-      out.push(coin.toCoin());
-
-    return out;
-  }
-
-  insert(tx, index) {
-    const output = tx.outputs[index];
-    const hash = tx.hash();
-    const addr = output.getHash();
-
-    if (!addr)
-      return;
-
-    let items = this.index.get(addr);
-
-    if (!items) {
-      items = new BufferMap();
-      this.index.set(addr, items);
-    }
-
-    const key = Outpoint.toKey(hash, index);
-
-    assert(!items.has(key));
-    items.set(key, new IndexedCoin(tx, index));
-
-    this.map.set(key, addr);
-  }
-
-  remove(hash, index) {
-    const key = Outpoint.toKey(hash, index);
-    const addr = this.map.get(key);
-
-    if (!addr)
-      return;
-
-    const items = this.index.get(addr);
-
-    assert(items);
-    assert(items.has(key));
-    items.delete(key);
-
-    if (items.size === 0)
-      this.index.delete(addr);
-
-    this.map.delete(key);
-  }
-}
-
-/**
- * Indexed Coin
- * @ignore
- */
-
-class IndexedCoin {
-  /**
-   * Create an indexed coin.
-   * @constructor
-   * @param {TX} tx
-   * @param {Number} index
-   */
-
-  constructor(tx, index) {
-    this.tx = tx;
-    this.index = index;
-  }
-
-  toCoin() {
-    return Coin.fromTX(this.tx, this.index, -1);
   }
 }
 

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -87,16 +87,16 @@ class Mempool extends EventEmitter {
     if (this.options.persistent) {
       const entries = await this.cache.getEntries();
 
-      for (const entry of entries)
-        this.trackEntry(entry);
-
       for (const entry of entries) {
-        this.updateAncestors(entry, addFee);
+        const tx = entry.tx;
+        const view = await this.getCoinView(entry.tx);
 
-        if (this.options.indexAddress) {
-          const view = await this.getCoinView(entry.tx);
-          this.indexEntry(entry, view);
-        }
+        const missing = this.maybeOrphan(tx, view);
+
+        if (missing)
+          continue;
+
+        await this.addEntry(entry, view);
       }
 
       this.logger.info(

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -1078,7 +1078,7 @@ class Mempool extends EventEmitter {
     this.updateAncestors(entry, addFee);
 
     this.emit('tx', tx, view);
-    this.emit('add entry', entry);
+    this.emit('add entry', entry, view);
 
     if (this.fees)
       this.fees.processTX(entry, this.chain.synced);

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -503,6 +503,28 @@ class Mempool extends EventEmitter {
   }
 
   /**
+   * Check whether coin is still unspent.
+   * @param {Hash} hash
+   * @param {Number} index
+   * @returns {boolean}
+   */
+
+  hasCoin(hash, index) {
+    const entry = this.map.get(hash);
+
+    if (!entry)
+      return false;
+
+    if (this.isSpent(hash, index))
+      return false;
+
+    if (index >= entry.tx.outputs.length)
+      return false;
+
+    return true;
+  }
+
+  /**
    * Check to see if a coin has been spent. This differs from
    * {@link ChainDB#isSpent} in that it actually maintains a
    * map of spent coins, whereas ChainDB may return `true`

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -11,6 +11,7 @@ const assert = require('bsert');
 const Chain = require('../blockchain/chain');
 const Fees = require('../mempool/fees');
 const Mempool = require('../mempool/mempool');
+const MempoolIndexer = require('../mempool/indexer');
 const Pool = require('../net/pool');
 const Miner = require('../mining/miner');
 const Node = require('./node');
@@ -144,7 +145,10 @@ class FullNode extends Node {
 
     // Indexers
     this.txindex = null;
-    if (this.config.bool('index-tx'))
+    this.addrindex = null;
+    this.mempoolIndex = null;
+
+    if (this.config.bool('index-tx')) {
       this.txindex = new TXIndexer({
         network: this.network,
         logger: this.logger,
@@ -152,16 +156,21 @@ class FullNode extends Node {
         memory: this.config.bool('memory'),
         prefix: this.config.filter('index').str('prefix') || this.config.prefix
       });
+    }
 
-    this.addrindex = null;
-    if (this.config.bool('index-address'))
-      this.addrindex= new AddrIndexer({
+    if (this.config.bool('index-address')) {
+      this.addrindex = new AddrIndexer({
         network: this.network,
         logger: this.logger,
         chain: this.chain,
         memory: this.config.bool('memory'),
         prefix: this.config.filter('index').str('prefix') || this.config.prefix
       });
+
+      this.mempoolIndex = new MempoolIndexer({
+        mempool: this.mempool
+      });
+    }
 
     this.init();
   }
@@ -472,7 +481,7 @@ class FullNode extends Node {
    */
 
   async getMetaByAddress(addrs) {
-    const mempool = this.mempool.getMetaByAddress(addrs);
+    const mempool = this.mempoolIndex.getMetaByAddress(addrs);
 
     if (this.txindex && this.addrindex) {
       if (!Array.isArray(addrs))

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -232,6 +232,9 @@ class FullNode extends Node {
     this.chain.on('reset', async (tip) => {
       try {
         await this.mempool._reset();
+
+        if (this.mempoolIndex)
+          this.mempoolIndex.reset();
       } catch (e) {
         this.error(e);
       }
@@ -450,11 +453,10 @@ class FullNode extends Node {
    */
 
   async getCoinsByAddress(addrs) {
-    const mempool = this.mempool.getCoinsByAddress(addrs);
-
     if (!this.addrindex)
-      return mempool;
+      return [];
 
+    const mempool = this.mempoolIndex.getCoinsByAddress(addrs);
     const index = await this.addrindex.getCoinsByAddress(addrs);
     const out = [];
 
@@ -481,24 +483,26 @@ class FullNode extends Node {
    */
 
   async getMetaByAddress(addrs) {
+    if (!this.addrindex)
+      return [];
+
     const mempool = this.mempoolIndex.getMetaByAddress(addrs);
 
-    if (this.txindex && this.addrindex) {
-      if (!Array.isArray(addrs))
-        addrs = [addrs];
+    if (!this.txindex)
+      return mempool;
 
-      const hashes = await this.addrindex.getHashesByAddress(addrs);
-      const mtxs = [];
+    if (!Array.isArray(addrs))
+      addrs = [addrs];
 
-      for (const hash of hashes) {
-        const mtx = await this.txindex.getMeta(hash);
-        assert(mtx);
-        mtxs.push(mtx);
-      }
-      return mtxs.concat(mempool);
+    const hashes = await this.addrindex.getHashesByAddress(addrs);
+    const mtxs = [];
+
+    for (const hash of hashes) {
+      const mtx = await this.txindex.getMeta(hash);
+      assert(mtx);
+      mtxs.push(mtx);
     }
-
-    return mempool;
+    return mtxs.concat(mempool);
   }
 
   /**

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -20,6 +20,7 @@ const Input = require('../lib/primitives/input');
 const Script = require('../lib/script/script');
 const MemWallet = require('./util/memwallet');
 const MempoolIndexer = require('../lib/mempool/indexer');
+const {BufferSet} = require('buffer-map');
 
 const VERIFY_NONE = common.flags.VERIFY_NONE;
 const SHTYPE = Script.hashType.ALL | Script.hashType.SIGHASH_FORKID;
@@ -39,7 +40,8 @@ const chain = new Chain({
 const mempool = new Mempool({
   chain,
   workers,
-  memory: true
+  memory: true,
+  indexAddress: true
 });
 
 const wallet = new MemWallet();
@@ -311,8 +313,7 @@ describe('Mempool', function() {
     const mempool = new Mempool({
       chain,
       workers,
-      memory: true,
-      indexAddress: true
+      memory: true
     });
 
     const indexer = new MempoolIndexer({ mempool });
@@ -873,6 +874,263 @@ describe('Mempool', function() {
         assert.strictEqual(txs.length, 2);
         assert.strictEqual(coins.length, 0);
       }
+    });
+  });
+
+  describe('Mempool persistent cache', function () {
+    const workers = new WorkerPool({
+      enabled: true
+    });
+
+    const chain = new Chain({
+      memory: true,
+      workers
+    });
+
+    const mempool = new Mempool({
+      chain,
+      workers,
+      memory: true,
+      persistent: true
+    });
+
+    const indexer = new MempoolIndexer({ mempool });
+
+    before(async () => {
+      await mempool.open();
+      await chain.open();
+      await workers.open();
+    });
+
+    after(async () => {
+      await mempool.close();
+      await chain.close();
+      await workers.close();
+    });
+
+    // number of coins available in chaincoins. (100k satoshi per coin)
+    const N = 100;
+    const chaincoins = new MemWallet();
+    const wallet = new MemWallet();
+
+    it('should create coins in chain', async () => {
+      const mtx = new MTX();
+      mtx.addInput(new Input());
+
+      for (let i = 0; i < N; i++) {
+        const addr = chaincoins.createReceive().getAddress();
+        mtx.addOutput(addr, 100000);
+      }
+
+      const cb = mtx.toTX();
+      const block = await getMockBlock(chain, [cb], false);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+
+      // add 100 blocks
+      // so we don't get premature spend of coinbase.
+      for (let i = 0; i < 100; i++) {
+        const block = await getMockBlock(chain);
+        const entry = await chain.add(block, VERIFY_NONE);
+
+        await mempool._addBlock(entry, block.txs);
+      }
+
+      chaincoins.addTX(cb);
+    });
+
+    it('should create txs and coins in the mempool', async () => {
+      const coins = chaincoins.getCoins();
+
+      assert.strictEqual(coins.length, N);
+
+      const addrs = [];
+      const txs = 20;
+      const spend = 5;
+
+      for (let i = 0; i < txs; i++)
+        addrs.push(wallet.createReceive().getAddress());
+
+      const mempoolTXs = new BufferSet();
+      const mempoolCoins = new BufferSet();
+
+      // send 15 txs to the wallet
+      for (let i = 0; i < txs - spend; i++) {
+        const mtx = new MTX();
+
+        mtx.addCoin(coins[i]);
+        mtx.addOutput(addrs[i], 90000);
+
+        chaincoins.sign(mtx);
+
+        const tx = mtx.toTX();
+        const missing = await mempool.addTX(tx);
+
+        assert.strictEqual(missing, null);
+        assert(mempool.hasCoin(tx.hash(), 0));
+
+        // indexer checks
+        {
+          const txs = indexer.getTXByAddress(addrs[i]);
+          const coins = indexer.getCoinsByAddress(addrs[i]);
+
+          assert.strictEqual(txs.length, 1);
+          assert.strictEqual(coins.length, 1);
+          assert.bufferEqual(txs[0].hash(), tx.hash());
+          assert.bufferEqual(coins[0].hash, tx.hash());
+          assert.strictEqual(coins[0].index, 0);
+        }
+
+        wallet.addTX(tx);
+
+        mempoolTXs.add(tx.hash());
+        mempoolCoins.add(Outpoint.fromTX(tx, 0).toKey());
+      }
+
+      // spend first 5 coins from the mempool
+      for (let i = 0; i < spend; i++) {
+        const coin = wallet.getCoins()[0];
+        const addr = addrs[txs - spend + i];
+        const mtx = new MTX();
+
+        mtx.addCoin(coin);
+        mtx.addOutput(addr, 80000);
+
+        wallet.sign(mtx);
+
+        const tx = mtx.toTX();
+        const missing = await mempool.addTX(tx);
+
+        assert.strictEqual(missing, null);
+        assert(!mempool.hasCoin(coin.hash, 0));
+        assert(mempool.hasCoin(tx.hash(), 0));
+
+        {
+          const txs = indexer.getTXByAddress(addr);
+          const coins = indexer.getCoinsByAddress(addr);
+
+          assert.strictEqual(txs.length, 1);
+          assert.strictEqual(coins.length, 1);
+        }
+
+        {
+          const txs = indexer.getTXByAddress(addrs[i]);
+          const coins = indexer.getCoinsByAddress(addrs[i]);
+
+          assert.strictEqual(txs.length, 2);
+          assert.strictEqual(coins.length, 0);
+        }
+
+        mempoolTXs.add(tx.hash());
+        mempoolCoins.delete(coin.toKey());
+        mempoolCoins.add(Outpoint.fromTX(tx, 0).toKey());
+
+        wallet.addTX(tx);
+      }
+
+      const verifyMempoolState = (mempool, indexer) => {
+        // verify general state of the mempool
+        assert.strictEqual(mempool.map.size, txs);
+        assert.strictEqual(mempool.spents.size, txs);
+
+        assert.strictEqual(indexer.txIndex.map.size, txs);
+        assert.strictEqual(indexer.coinIndex.map.size, txs - spend);
+
+        // verify txs are same
+        for (const val of mempoolTXs.values())
+          assert(mempool.getTX(val));
+
+        for (const opkey of mempoolCoins.values()) {
+          const outpoint = Outpoint.fromRaw(opkey);
+          assert(mempool.hasCoin(outpoint.hash, outpoint.index));
+        }
+
+        // coins in these txs are spent
+        for (let i = 0; i < spend; i++) {
+          const addr = addrs[i];
+
+          {
+            const txs = indexer.getTXByAddress(addr);
+            const coins = indexer.getCoinsByAddress(addr);
+
+            assert.strictEqual(txs.length, 2);
+            assert.strictEqual(coins.length, 0);
+          }
+        }
+
+        // these txs are untouched
+        for (let i = spend; i < txs - spend; i++) {
+          const addr = addrs[i];
+
+          {
+            const txs = indexer.getTXByAddress(addr);
+            const coins = indexer.getCoinsByAddress(addr);
+
+            assert.strictEqual(txs.length, 1);
+            assert.strictEqual(coins.length, 1);
+          }
+        }
+
+        // these are txs spending mempool txs
+        for (let i = txs - spend; i < txs; i++) {
+          const addr = addrs[i];
+
+          {
+            const txs = indexer.getTXByAddress(addr);
+            const coins = indexer.getCoinsByAddress(addr);
+
+            assert.strictEqual(txs.length, 1);
+            assert.strictEqual(coins.length, 1);
+          }
+        }
+      };
+
+      verifyMempoolState(mempool, indexer);
+
+      // hack: to get in memory cache in new mempool.
+      const cache = mempool.cache;
+
+      // we need to manually sync because
+      // when first block was mined there were no mempool txs.
+      await cache.sync(chain.tip.hash);
+
+      // and apply batch to the memdb.
+      await cache.flush();
+      await mempool.close();
+
+      let err;
+      {
+        const mempool = new Mempool({
+          chain,
+          workers,
+          memory: true,
+          persistent: true
+        });
+
+        mempool.cache = cache;
+
+        const indexer = new MempoolIndexer({ mempool });
+
+        // this needs to come after `indexer` initialization
+        // otherwise indexer wont get add entry events from the mempool.
+        await mempool.open();
+
+        try {
+          verifyMempoolState(mempool, indexer);
+        } catch (e) {
+          err = e;
+        } finally {
+          await cache.wipe();
+          await mempool.close();
+        }
+      }
+
+      // reopen for after cleanup
+      await mempool.open();
+
+      if (err)
+        throw err;
     });
   });
 });

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -5,6 +5,8 @@
 
 const assert = require('./util/assert');
 const random = require('bcrypto/lib/random');
+const common = require('../lib/blockchain/common');
+const Block = require('../lib/primitives/block');
 const MempoolEntry = require('../lib/mempool/mempoolentry');
 const Mempool = require('../lib/mempool/mempool');
 const WorkerPool = require('../lib/workers/workerpool');
@@ -14,9 +16,12 @@ const Coin = require('../lib/primitives/coin');
 const KeyRing = require('../lib/primitives/keyring');
 const Address = require('../lib/primitives/address');
 const Outpoint = require('../lib/primitives/outpoint');
+const Input = require('../lib/primitives/input');
 const Script = require('../lib/script/script');
 const MemWallet = require('./util/memwallet');
+const MempoolIndexer = require('../lib/mempool/indexer');
 
+const VERIFY_NONE = common.flags.VERIFY_NONE;
 const SHTYPE = Script.hashType.ALL | Script.hashType.SIGHASH_FORKID;
 
 const ONE_HASH = Buffer.alloc(32, 0x00);
@@ -33,15 +38,15 @@ const chain = new Chain({
 
 const mempool = new Mempool({
   chain,
-  memory: true,
-  workers
+  workers,
+  memory: true
 });
 
 const wallet = new MemWallet();
 
 let cachedTX = null;
 
-function dummyInput(script, hash) {
+function dummyInput(mempool, script, hash, value = 70000) {
   const coin = new Coin();
   coin.height = 0;
   coin.value = 0;
@@ -51,7 +56,7 @@ function dummyInput(script, hash) {
 
   const fund = new MTX();
   fund.addCoin(coin);
-  fund.addOutput(script, 70000);
+  fund.addOutput(script, value);
 
   const [tx, view] = fund.commit();
 
@@ -61,14 +66,41 @@ function dummyInput(script, hash) {
 
   return Coin.fromTX(fund, 0, -1);
 }
+async function getMockBlock(chain, txs = [], cb = true) {
+  if (cb) {
+    const raddr = KeyRing.generate().getAddress();
+    const mtx = new MTX();
+    mtx.addInput(new Input());
+    mtx.addOutput(raddr, 0);
+
+    txs = [mtx.toTX(), ...txs];
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const time = chain.tip.time <= now ? chain.tip.time + 1 : now;
+
+  const block = new Block();
+  block.txs = txs;
+  block.prevBlock = chain.tip.hash;
+  block.time = time;
+  block.bits = await chain.getTarget(block.time, chain.tip);
+
+  return block;
+}
 
 describe('Mempool', function() {
   this.timeout(5000);
 
-  it('should open mempool', async () => {
+  before(async () => {
     await workers.open();
     await chain.open();
     await mempool.open();
+  });
+
+  after(async () => {
+    await workers.close();
+    await chain.close();
+    await mempool.close();
   });
 
   it('should handle incoming orphans and TXs', async () => {
@@ -80,7 +112,7 @@ describe('Mempool', function() {
 
     const script = Script.fromPubkey(key.publicKey);
 
-    t1.addCoin(dummyInput(script, ONE_HASH));
+    t1.addCoin(dummyInput(mempool, script, ONE_HASH));
 
     const sig = t1.signature(0, script, 70000, key.privateKey, SHTYPE);
 
@@ -186,7 +218,7 @@ describe('Mempool', function() {
     const prev = Script.fromPubkey(key.publicKey);
     const prevHash = random.randomBytes(32);
 
-    tx.addCoin(dummyInput(prev, prevHash));
+    tx.addCoin(dummyInput(mempool, prev, prevHash));
     tx.setLocktime(200);
 
     chain.tip.height = 200;
@@ -208,7 +240,7 @@ describe('Mempool', function() {
     const prev = Script.fromPubkey(key.publicKey);
     const prevHash = random.randomBytes(32);
 
-    tx.addCoin(dummyInput(prev, prevHash));
+    tx.addCoin(dummyInput(mempool, prev, prevHash));
     tx.setLocktime(200);
     chain.tip.height = 200 - 1;
 
@@ -237,7 +269,7 @@ describe('Mempool', function() {
     const prev = Script.fromPubkey(key.publicKey);
     const prevHash = random.randomBytes(32);
 
-    tx.addCoin(dummyInput(prev, prevHash));
+    tx.addCoin(dummyInput(mempool, prev, prevHash));
 
     let err;
     try {
@@ -260,14 +292,467 @@ describe('Mempool', function() {
 
     assert(mempool.hasReject(cachedTX.hash()));
 
-    await mempool.addBlock({ height: 1 }, [tx.toTX()]);
+    await mempool.addBlock({ height: 1 }, [null, tx.toTX()]);
 
     assert(!mempool.hasReject(cachedTX.hash()));
   });
 
-  it('should destroy mempool', async () => {
-    await mempool.close();
-    await chain.close();
-    await workers.close();
+  describe('Index', function () {
+    const workers = new WorkerPool({
+      enabled: true
+    });
+
+    const chain = new Chain({
+      memory: true,
+      workers
+    });
+
+    const mempool = new Mempool({
+      chain,
+      workers,
+      memory: true,
+      indexAddress: true
+    });
+
+    const indexer = new MempoolIndexer({ mempool });
+
+    before(async () => {
+      await mempool.open();
+      await chain.open();
+      await workers.open();
+    });
+
+    after(async () => {
+      await mempool.close();
+      await chain.close();
+      await workers.close();
+    });
+
+    // keys that we will use
+    const N = 100;
+    const chaincoins = new MemWallet();
+    const wallet = new MemWallet();
+
+    it('should create coins in chain', async () => {
+      const mtx = new MTX();
+      mtx.addInput(new Input());
+
+      for (let i = 0; i < N; i++) {
+        const addr = chaincoins.createReceive().getAddress();
+        mtx.addOutput(addr, 100000);
+      }
+
+      const cb = mtx.toTX();
+      const block = await getMockBlock(chain, [cb], false);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+
+      // add 100 blocks
+      // so we don't get premature spend of coinbase.
+      for (let i = 0; i < 100; i++) {
+        const block = await getMockBlock(chain);
+        const entry = await chain.add(block, VERIFY_NONE);
+
+        await mempool._addBlock(entry, block.txs);
+      }
+
+      chaincoins.addTX(cb);
+    });
+
+    it('should spend txs and coins in the mempool', async () => {
+      // verify coins are removed from the coin index
+      const coin = chaincoins.getCoins()[0];
+      const addr = wallet.createReceive().getAddress();
+
+      const mtx1 = new MTX();
+
+      mtx1.addCoin(coin);
+      mtx1.addOutput(addr, 90000);
+
+      chaincoins.sign(mtx1);
+
+      const tx1 = mtx1.toTX();
+
+      chaincoins.addTX(tx1, -1);
+      wallet.addTX(tx1, -1);
+
+      {
+        const missing = await mempool.addTX(tx1);
+        assert.strictEqual(missing, null);
+      }
+
+      assert(mempool.hasCoin(tx1.hash(), 0));
+
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const metas = indexer.getMetaByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 1);
+        assert.strictEqual(metas.length, 1);
+        assert.strictEqual(coins.length, 1);
+
+        assert.bufferEqual(txs[0].hash(), tx1.hash());
+        assert.bufferEqual(coins[0].hash, tx1.hash());
+        assert.strictEqual(coins[0].index, 0);
+      }
+
+      const mtx2 = new MTX();
+
+      mtx2.addTX(tx1, 0, -1);
+      mtx2.addOutput(addr, 80000);
+
+      wallet.sign(mtx2);
+
+      const tx2 = mtx2.toTX();
+
+      {
+        const missing = await mempool.addTX(tx2);
+        assert.strictEqual(missing, null);
+      }
+
+      wallet.addTX(tx2, -1);
+
+      assert(!mempool.hasCoin(tx1.hash(), 0));
+      assert(mempool.hasCoin(tx2.hash(), 0));
+
+      {
+        const txs = indexer.getTXByAddress(addr);
+        const coins = indexer.getCoinsByAddress(addr);
+
+        assert.strictEqual(txs.length, 2);
+        assert.strictEqual(coins.length, 1);
+
+        assert.bufferEqual(coins[0].hash, tx2.hash());
+        assert.strictEqual(coins[0].index, 0);
+      }
+    });
+
+    it('should spend resolved orphans', async () => {
+      const coin = chaincoins.getCoins()[0];
+      const addr = wallet.createReceive().getAddress();
+
+      const pmtx = new MTX();
+
+      pmtx.addOutput(addr, 90000);
+      pmtx.addCoin(coin);
+
+      chaincoins.sign(pmtx);
+
+      const parentTX = pmtx.toTX();
+
+      const cmtx = new MTX();
+
+      cmtx.addTX(pmtx.toTX(), 0, -1);
+      cmtx.addOutput(addr, 80000);
+
+      wallet.sign(cmtx);
+
+      const childTX = cmtx.toTX();
+
+      {
+        // create orphan
+        const missing = await mempool.addTX(childTX);
+
+        // we only have one input missing
+        assert.strictEqual(missing.length, 1);
+      }
+
+      // TODO: make sure indexes have not changed.
+
+      {
+        // orphans are not coins
+        const childCoin = mempool.getCoin(childTX.hash(), 0);
+        assert.strictEqual(childCoin, null);
+      }
+
+      {
+        // orphans should be resolved.
+        const missing = await mempool.addTX(parentTX);
+        assert.strictEqual(missing, null);
+
+        // coins should be available once they are resolved
+        const parentCoin = mempool.getCoin(parentTX.hash(), 0);
+        assert.strictEqual(parentCoin, null); // we spent this.
+
+        const childCoin = mempool.getCoin(childTX.hash(), 0);
+        assert(childCoin);
+      }
+
+      // TODO: make sure indexes are updated correctly
+
+      // update coins in wallets
+      for (const tx of [parentTX, childTX]) {
+        chaincoins.addTX(tx);
+        wallet.addTX(tx);
+      }
+    });
+
+    it('should remove double spend tx from mempool', async () => {
+      const coin = chaincoins.getCoins()[0];
+
+      const addr = wallet.createReceive().getAddress();
+      const randomAddress = KeyRing.generate().getAddress();
+
+      // we check double spending our mempool tx
+      const mtx1 = new MTX();
+
+      mtx1.addCoin(coin);
+      mtx1.addOutput(addr, 90000);
+
+      chaincoins.sign(mtx1);
+
+      // this will double spend in block
+      const mtx2 = new MTX();
+
+      mtx2.addCoin(coin);
+      mtx2.addOutput(randomAddress, 90000);
+
+      chaincoins.sign(mtx2);
+
+      const tx1 = mtx1.toTX();
+      const tx2 = mtx2.toTX();
+
+      {
+        const missing = await mempool.addTX(tx1);
+        assert.strictEqual(missing, null);
+      }
+
+      // TODO: verify we have coin/tx in indexer
+      assert(mempool.hasCoin(tx1.hash(), 0));
+
+      const block = await getMockBlock(chain, [tx2]);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+
+      // TODO: verify we don't have coin/tx in indexer anymore.
+      assert(!mempool.hasCoin(tx1.hash(), 0));
+
+      chaincoins.addTX(tx2);
+    });
+
+    it('should remove confirmed txs from indexer', async () => {
+      const coin = chaincoins.getCoins()[0];
+      const addr = wallet.createReceive().getAddress();
+
+      const mtx = new MTX();
+
+      mtx.addCoin(coin);
+      mtx.addOutput(addr, 90000);
+
+      chaincoins.sign(mtx);
+
+      const tx = mtx.toTX();
+
+      await mempool.addTX(tx);
+
+      assert(mempool.hasCoin(tx.hash(), 0));
+
+      // TODO: verify we have coin in indexer.
+
+      const block = await getMockBlock(chain, [tx]);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+
+      // TODO: verify we don't have coin in indexer anymore.
+      assert(!mempool.hasCoin(tx.hash(), 0));
+
+      chaincoins.addTX(tx);
+      wallet.addTX(tx);
+    });
+
+    it('should add coin from orphan once resolved in a block', async () => {
+      const coin = chaincoins.getCoins()[0];
+      const addr = wallet.createReceive().getAddress();
+
+      const pmtx = new MTX();
+
+      pmtx.addCoin(coin);
+      pmtx.addOutput(addr, 90000);
+
+      chaincoins.sign(pmtx);
+
+      const parentTX = pmtx.toTX();
+      const cmtx = new MTX();
+
+      cmtx.addTX(parentTX, 0, -1);
+      cmtx.addOutput(addr, 80000);
+
+      wallet.sign(cmtx);
+
+      const childTX = cmtx.toTX();
+
+      {
+        const missing = await mempool.addTX(childTX);
+        assert.strictEqual(missing.length, 1);
+      }
+
+      // TODO: verify we don't have coins have not changed.
+
+      const block = await getMockBlock(chain, [parentTX]);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+
+      assert(mempool.hasCoin(childTX.hash(), 0));
+
+      // TODO: verify resolved orphan is new coin
+
+      chaincoins.addTX(parentTX);
+      wallet.addTX(parentTX);
+      wallet.addTX(childTX);
+    });
+
+    it('should recover coin form partial double spend', async () => {
+      const coins = chaincoins.getCoins();
+      const coin1 = coins[0];
+      const coin2 = coins[1];
+      const addr = wallet.createReceive().getAddress();
+      const raddr = KeyRing.generate().getAddress();
+
+      // this will get double spent in a block
+      const mtx1 = new MTX();
+
+      mtx1.addCoin(coin1);
+      mtx1.addOutput(addr, 90000);
+
+      chaincoins.sign(mtx1);
+
+      const tx1 = mtx1.toTX();
+
+      // this should recover as coin
+      const mtx2 = new MTX();
+
+      mtx2.addCoin(coin2);
+      mtx2.addOutput(addr, 90000);
+
+      chaincoins.sign(mtx2);
+
+      const tx2 = mtx2.toTX();
+
+      // this will get orphaned because of double spend
+      const mtx3 = new MTX();
+
+      mtx3.addTX(tx1, 0, -1);
+      mtx3.addTX(tx2, 0, -1);
+      mtx3.addOutput(raddr, 170000);
+
+      wallet.sign(mtx3);
+      const tx3 = mtx3.toTX();
+
+      // this double spends mtx1
+      const mtx4 = new MTX();
+
+      mtx4.addCoin(coin1);
+      mtx4.addOutput(raddr, 90000);
+
+      chaincoins.sign(mtx4);
+
+      const tx4 = mtx4.toTX();
+
+      {
+        const missing = await mempool.addTX(tx1);
+        assert.strictEqual(missing, null);
+
+        assert(mempool.hasCoin(tx1.hash(), 0));
+      }
+
+      {
+        const missing = await mempool.addTX(tx2);
+        assert.strictEqual(missing, null);
+
+        assert(mempool.hasCoin(tx1.hash(), 0));
+        assert(mempool.hasCoin(tx2.hash(), 0));
+      }
+
+      {
+        const missing = await mempool.addTX(tx3);
+        assert.strictEqual(missing, null);
+
+        assert(!mempool.hasCoin(tx1.hash(), 0));
+        assert(!mempool.hasCoin(tx2.hash(), 0));
+        assert(mempool.hasCoin(tx3.hash(), 0));
+      }
+
+      // TODO: verify indexer has the right state
+
+      const block = await getMockBlock(chain, [tx4]);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+      assert(!mempool.hasCoin(tx1.hash(), 0));
+      assert(mempool.hasCoin(tx2.hash(), 0));
+      assert(!mempool.hasCoin(tx3.hash(), 0));
+      assert(!mempool.hasCoin(tx4.hash(), 0));
+
+      // TODO: verify we only have tx2 coins in indexer
+
+      chaincoins.addBlock(entry, block.txs);
+      wallet.addBlock(entry, block.txs);
+
+      chaincoins.addTX(tx2);
+      wallet.addTX(tx2);
+    });
+
+    it('should make unconfirmed coins available', async () => {
+      const coin = chaincoins.getCoins()[0];
+      const addr = wallet.createReceive().getAddress();
+      const raddr = KeyRing.generate().getAddress();
+
+      const pmtx = new MTX();
+
+      pmtx.addCoin(coin);
+      pmtx.addOutput(addr, 90000);
+
+      chaincoins.sign(pmtx);
+
+      const ptx = pmtx.toTX();
+
+      const cmtx = new MTX();
+
+      cmtx.addTX(ptx, 0, -1);
+      cmtx.addOutput(raddr, 80000);
+
+      wallet.sign(cmtx);
+
+      const ctx = cmtx.toTX();
+
+      {
+        const missing = await mempool.addTX(ptx);
+        assert.strictEqual(missing, null);
+      }
+
+      assert(mempool.hasCoin(ptx.hash(), 0));
+      // TODO: make sure we have coin in indexer,
+      // even though we test this in previous tests.
+
+      {
+        const missing = await mempool.addTX(ctx);
+        assert.strictEqual(missing, null);
+      }
+
+      assert(!mempool.hasCoin(ptx.hash(), 0));
+      assert(mempool.hasCoin(ctx.hash(), 0));
+
+      const block = await getMockBlock(chain, [ptx]);
+      const entry = await chain.add(block, VERIFY_NONE);
+
+      await mempool._addBlock(entry, block.txs);
+
+      assert(!mempool.hasCoin(ptx.hash(), 0));
+      assert(mempool.hasCoin(ctx.hash(), 0));
+
+      // TODO: make sure we don't have coin/tx in indexer anymore
+
+      await chain.disconnect(entry);
+      await mempool._removeBlock(entry, block.txs);
+
+      assert(!mempool.hasCoin(ptx.hash(), 0));
+      assert(mempool.hasCoin(ctx.hash(), 0));
+      // TODO: verify we have coins in indexer
+    });
   });
 });


### PR DESCRIPTION
This separate coin/tx indexer from the mempool and moves to its separate file.

- Separate mempool indexer from the mempool.
- Fix mempool indexer issues on reorg
- Fix mempool indexer issues when recovering from persistent storage.
- Add `view` to the `add entry` event.

This should fix issues: https://github.com/bcoin-org/bcoin/issues/594 and https://github.com/bcoin-org/bcoin/issues/499.

Other PRs:
 - bcoin: https://github.com/bcoin-org/bcoin/pull/650
 - hsd: https://github.com/handshake-org/hsd/pull/81

Bug description:
  New transaction(`add entry`) always adds outputs as coins, because even if its resolving orphan that will just result new `add entry` event which will unindex inputs, meaning outputs that are spent are mostly spent. Only exception being `unconfirmed` transaction, which does not resolve orphan in case it's spent in the mempool and it's outputs might be spent in the mempool.  
 _update_: This bug can also happen when using `persistent` flag. Database stores them sorted, so on recovery they are sorted by txids which breaks indexer logic which relies on txs coming in dependency order.

---
Note from `indexer`:
Handles TXIndex and CoinIndex for looking up by address.

Coin index in mempool keeps track of the coins available for an address
in the mempool, those that have not been indexed by chain indexer yet.

There are several reasons transaction can be added or removed from the
mempool, as well as coins associated with addresses with it.
 - Transaction was received from the network or orphan got resolved:
   - events: add entry and tx
   - We want to remove coins that are in tx inputs.
     If there are any - Meaning they are spending transaction in mempool
   - We want to add outputs as coins in the mempool.
   - If outputs are resolving orphans those orphans will be added via same
     events (tx and add entry)
 - Transaction was included in block
   - events: `remove entry` and `confirmed` OR `double spend`
     (Can potentially resolve orphans)
   - if tx was confirmed we wont have tx.hash() in the mempool,
     so we can leave things to removeEntry.
   - On double spend transaction that was spent in mempool
     will get unindexed(remove entry), which will recover
     all coins that are in the mempool. (inputs that were
     double spent wont be in the mempool (getTX will fail).
 - Transaction was removed because of memory constraints
   - events: `remove entry`
   - In this case we want to recover inputs as coins
 - on reorganization we need to also clean up coins
   - events: `unconfirmed` and `add entry` + `tx`
   - add tx creates new coins
   - on unconfirmed we need to recover outputs as coins
     (Unless they are not spent in mempool)

We don't need to take care of conflict as that event prevents tx from entering the mempool.

and orphan related events as they are not part of the coin or tx indexers as orphans.
