### PR TITLE
[rpc] add initialblockdownload to getblockchaininfo

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -578,6 +578,7 @@ class RPC extends RPCBase {
       difficulty: toDifficulty(this.chain.tip.bits),
       mediantime: await this.chain.getMedianTime(this.chain.tip),
       verificationprogress: this.chain.getProgress(),
+      initialblockdownload: this.chain.getProgress() <= 0.99,
       chainwork: this.chain.tip.chainwork.toString('hex', 64),
       pruned: this.chain.options.prune,
       softforks: this.getSoftforks(),

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -171,6 +171,7 @@ describe('HTTP', function() {
   it('should execute an rpc call', async () => {
     const info = await nclient.execute('getblockchaininfo', []);
     assert.strictEqual(info.blocks, 0);
+    assert.strictEqual(info.initialblockdownload, true);
   });
 
   it('should execute an rpc call with bool parameter', async () => {


### PR DESCRIPTION
Mimics the `initialblockdownload` added to `getblockchaininfo` in https://github.com/bitcoin/bitcoin/pull/11258.

I couldn't find a IBD estimator in the bcash codebase. This is probably not a good check for IBD status, but it's only supposed to be an estimate anyway.